### PR TITLE
Fix: TF2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ The main network architecture is as follows:
 ![NetWork_Architecture](./data/source_image/network_architecture.png)
 
 ## Installation
-This software has only been tested on ubuntu 16.04(x64), python3.5, cuda-9.0, cudnn-7.0 with a GTX-1070 GPU. 
-To install this software you need tensorflow 1.12.0 and other version of tensorflow has not been tested but I think 
-it will be able to work properly in tensorflow above version 1.12. Other required package you may install them by
+This project now targets **Python&nbsp;3.10+** and **TensorFlow&nbsp;2.12+**. Earlier
+versions of the README referenced Python&nbsp;3.5 and TensorFlow&nbsp;1.x, but the
+code has been updated to run on modern environments.
+Install the dependencies with
 
 ```
 pip3 install -r requirements.txt

--- a/lanenet_model/lanenet.py
+++ b/lanenet_model/lanenet.py
@@ -42,7 +42,7 @@ class LaneNet(cnn_basenet.CNNBaseModel):
         :param reuse
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
             # first extract image features
             extract_feats_result = self._frontend.build_model(
                 input_tensor=input_tensor,
@@ -70,7 +70,7 @@ class LaneNet(cnn_basenet.CNNBaseModel):
         :param reuse:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
             # first extract image features
             extract_feats_result = self._frontend.build_model(
                 input_tensor=input_tensor,

--- a/lanenet_model/lanenet_back_end.py
+++ b/lanenet_model/lanenet_back_end.py
@@ -37,12 +37,11 @@ class LaneNetBackEnd(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     @classmethod
     def _compute_class_weighted_cross_entropy_loss(cls, onehot_labels, logits, classes_weights):
@@ -101,9 +100,9 @@ class LaneNetBackEnd(cnn_basenet.CNNBaseModel):
         :param reuse:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
             # calculate class weighted binary seg loss
-            with tf.variable_scope(name_or_scope='binary_seg'):
+            with tf.compat.v1.variable_scope(name_or_scope='binary_seg'):
                 binary_label_onehot = tf.one_hot(
                     tf.reshape(
                         tf.cast(binary_label, tf.int32),
@@ -142,7 +141,7 @@ class LaneNetBackEnd(cnn_basenet.CNNBaseModel):
                     raise NotImplementedError
 
             # calculate class weighted instance seg loss
-            with tf.variable_scope(name_or_scope='instance_seg'):
+            with tf.compat.v1.variable_scope(name_or_scope='instance_seg'):
 
                 pix_bn = self.layerbn(
                     inputdata=instance_seg_logits, is_training=self._is_training, name='pix_bn')
@@ -189,13 +188,13 @@ class LaneNetBackEnd(cnn_basenet.CNNBaseModel):
         :param reuse:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
 
-            with tf.variable_scope(name_or_scope='binary_seg'):
+            with tf.compat.v1.variable_scope(name_or_scope='binary_seg'):
                 binary_seg_score = tf.nn.softmax(logits=binary_seg_logits)
                 binary_seg_prediction = tf.argmax(binary_seg_score, axis=-1)
 
-            with tf.variable_scope(name_or_scope='instance_seg'):
+            with tf.compat.v1.variable_scope(name_or_scope='instance_seg'):
 
                 pix_bn = self.layerbn(
                     inputdata=instance_seg_logits, is_training=self._is_training, name='pix_bn')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ opencv_contrib_python
 numpy
 scikit_learn
 PyYAML
-tensorflow
+tensorflow>=2.12
+keras>=2.12
+tensorboard>=2.12

--- a/semantic_segmentation_zoo/bisenet_v2.py
+++ b/semantic_segmentation_zoo/bisenet_v2.py
@@ -35,11 +35,11 @@ class _StemBlock(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     def _conv_block(self, input_tensor, k_size, output_channels, stride,
                     name, padding='SAME', use_bias=False, need_activate=False):
@@ -54,7 +54,7 @@ class _StemBlock(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -83,7 +83,7 @@ class _StemBlock(cnn_basenet.CNNBaseModel):
         output_channels = kwargs['output_channels']
         if 'padding' in kwargs:
             self._padding = kwargs['padding']
-        with tf.variable_scope(name_or_scope=name_scope):
+        with tf.compat.v1.variable_scope(name_or_scope=name_scope):
             input_tensor = self._conv_block(
                 input_tensor=input_tensor,
                 k_size=3,
@@ -94,7 +94,7 @@ class _StemBlock(cnn_basenet.CNNBaseModel):
                 use_bias=False,
                 need_activate=True
             )
-            with tf.variable_scope(name_or_scope='downsample_branch_left'):
+            with tf.compat.v1.variable_scope(name_or_scope='downsample_branch_left'):
                 branch_left_output = self._conv_block(
                     input_tensor=input_tensor,
                     k_size=1,
@@ -115,7 +115,7 @@ class _StemBlock(cnn_basenet.CNNBaseModel):
                     use_bias=False,
                     need_activate=True
                 )
-            with tf.variable_scope(name_or_scope='downsample_branch_right'):
+            with tf.compat.v1.variable_scope(name_or_scope='downsample_branch_right'):
                 branch_right_output = self.maxpooling(
                     inputdata=input_tensor,
                     kernel_size=3,
@@ -156,11 +156,11 @@ class _ContextEmbedding(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     def _conv_block(self, input_tensor, k_size, output_channels, stride,
                     name, padding='SAME', use_bias=False, need_activate=False):
@@ -175,7 +175,7 @@ class _ContextEmbedding(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -204,7 +204,7 @@ class _ContextEmbedding(cnn_basenet.CNNBaseModel):
         output_channels = input_tensor.get_shape().as_list()[-1]
         if 'padding' in kwargs:
             self._padding = kwargs['padding']
-        with tf.variable_scope(name_or_scope=name_scope):
+        with tf.compat.v1.variable_scope(name_or_scope=name_scope):
             result = tf.reduce_mean(input_tensor, axis=[1, 2], keepdims=True, name='global_avg_pooling')
             result = self.layerbn(result, self._is_training, 'bn')
             result = self._conv_block(
@@ -251,11 +251,11 @@ class _GatherExpansion(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     def _conv_block(self, input_tensor, k_size, output_channels, stride,
                     name, padding='SAME', use_bias=False, need_activate=False):
@@ -270,7 +270,7 @@ class _GatherExpansion(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -296,7 +296,7 @@ class _GatherExpansion(cnn_basenet.CNNBaseModel):
         :return:
         """
         input_tensor_channels = input_tensor.get_shape().as_list()[-1]
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self._conv_block(
                 input_tensor=input_tensor,
                 k_size=3,
@@ -340,7 +340,7 @@ class _GatherExpansion(cnn_basenet.CNNBaseModel):
         :return:
         """
         input_tensor_channels = input_tensor.get_shape().as_list()[-1]
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             input_proj = self.depthwise_conv(
                 input_tensor=input_tensor,
                 kernel_size=3,
@@ -422,7 +422,7 @@ class _GatherExpansion(cnn_basenet.CNNBaseModel):
         if 'e' in kwargs:
             self._expansion_factor = kwargs['e']
 
-        with tf.variable_scope(name_or_scope=name_scope):
+        with tf.compat.v1.variable_scope(name_or_scope=name_scope):
             if self._stride == 1:
                 result = self._apply_ge_when_stride_equal_one(
                     input_tensor=input_tensor,
@@ -461,11 +461,11 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     def _conv_block(self, input_tensor, k_size, output_channels, stride,
                     name, padding='SAME', use_bias=False, need_activate=False):
@@ -480,7 +480,7 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -511,8 +511,8 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
         if 'padding' in kwargs:
             self._padding = kwargs['padding']
 
-        with tf.variable_scope(name_or_scope=name_scope):
-            with tf.variable_scope(name_or_scope='detail_branch'):
+        with tf.compat.v1.variable_scope(name_or_scope=name_scope):
+            with tf.compat.v1.variable_scope(name_or_scope='detail_branch'):
                 detail_branch_remain = self.depthwise_conv(
                     input_tensor=detail_input_tensor,
                     kernel_size=3,
@@ -550,7 +550,7 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
                     name='avg_pooling_block'
                 )
 
-            with tf.variable_scope(name_or_scope='semantic_branch'):
+            with tf.compat.v1.variable_scope(name_or_scope='semantic_branch'):
                 semantic_branch_remain = self.depthwise_conv(
                     input_tensor=semantic_input_tensor,
                     kernel_size=3,
@@ -581,14 +581,15 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
                     use_bias=False,
                     need_activate=False
                 )
-                semantic_branch_upsample = tf.image.resize_bilinear(
+                semantic_branch_upsample = tf.image.resize(
                     semantic_branch_upsample,
                     detail_input_tensor.shape[1:3],
+                    method='bilinear',
                     name='semantic_upsample_features'
                 )
                 semantic_branch_upsample = self.sigmoid(semantic_branch_upsample, name='semantic_upsample_sigmoid')
 
-            with tf.variable_scope(name_or_scope='aggregation_features'):
+            with tf.compat.v1.variable_scope(name_or_scope='aggregation_features'):
                 guided_features_remain = tf.multiply(
                     detail_branch_remain,
                     semantic_branch_upsample,
@@ -599,9 +600,10 @@ class _GuidedAggregation(cnn_basenet.CNNBaseModel):
                     semantic_branch_remain,
                     name='guided_semantic_features'
                 )
-                guided_features_upsample = tf.image.resize_bilinear(
+                guided_features_upsample = tf.image.resize(
                     guided_features_downsample,
                     detail_input_tensor.shape[1:3],
+                    method='bilinear',
                     name='guided_upsample_features'
                 )
                 guided_features = tf.add(guided_features_remain, guided_features_upsample, name='fused_features')
@@ -636,11 +638,11 @@ class _SegmentationHead(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     def _conv_block(self, input_tensor, k_size, output_channels, stride,
                     name, padding='SAME', use_bias=False, need_activate=False):
@@ -655,7 +657,7 @@ class _SegmentationHead(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -689,7 +691,7 @@ class _SegmentationHead(cnn_basenet.CNNBaseModel):
         if 'padding' in kwargs:
             self._padding = kwargs['padding']
 
-        with tf.variable_scope(name_or_scope=name_scope):
+        with tf.compat.v1.variable_scope(name_or_scope=name_scope):
             result = self._conv_block(
                 input_tensor=input_tensor,
                 k_size=3,
@@ -709,9 +711,10 @@ class _SegmentationHead(cnn_basenet.CNNBaseModel):
                 use_bias=False,
                 name='1x1_conv_block'
             )
-            result = tf.image.resize_bilinear(
+            result = tf.image.resize(
                 result,
                 output_tensor_size,
+                method='bilinear',
                 name='segmentation_head_logits'
             )
         return result
@@ -769,11 +772,11 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         if the net is used for training or not
         :return:
         """
-        if isinstance(self._phase, tf.Tensor):
-            phase = self._phase
+        if isinstance(self._phase, str):
+            return self._phase == 'train'
         else:
-            phase = tf.constant(self._phase, dtype=tf.string)
-        return tf.equal(phase, tf.constant('train', dtype=tf.string))
+            phase = self._phase
+            return tf.equal(phase, tf.constant('train', dtype=tf.string))
 
     @classmethod
     def _build_detail_branch_hyper_params(cls):
@@ -820,7 +823,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         :param use_bias:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self.conv2d(
                 inputdata=input_tensor,
                 out_channel=output_channels,
@@ -845,9 +848,9 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         :return:
         """
         result = input_tensor
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             for stage_name, stage_params in self._detail_branch_channels.items():
-                with tf.variable_scope(stage_name):
+                with tf.compat.v1.variable_scope(stage_name):
                     for block_index, param in enumerate(stage_params):
                         block_op = self._block_maps[param[0]]
                         k_size = param[1]
@@ -855,7 +858,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
                         stride = param[3]
                         repeat_times = param[4]
                         for repeat_index in range(repeat_times):
-                            with tf.variable_scope(name_or_scope='conv_block_{:d}_repeat_{:d}'.format(
+                            with tf.compat.v1.variable_scope(name_or_scope='conv_block_{:d}_repeat_{:d}'.format(
                                     block_index + 1, repeat_index + 1)):
                                 if stage_name == 'stage_3' and block_index == 1 and repeat_index == 1:
                                     result = block_op(
@@ -892,10 +895,10 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         seg_head_inputs = collections.OrderedDict()
         result = input_tensor
         source_input_tensor_size = input_tensor.get_shape().as_list()[1:3]
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             for stage_name, stage_params in self._semantic_branch_channels.items():
                 seg_head_input = input_tensor
-                with tf.variable_scope(stage_name):
+                with tf.compat.v1.variable_scope(stage_name):
                     for block_index, param in enumerate(stage_params):
                         block_op_name = param[0]
                         block_op = self._block_maps[block_op_name]
@@ -904,7 +907,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
                         stride = param[4]
                         repeat_times = param[5]
                         for repeat_index in range(repeat_times):
-                            with tf.variable_scope(name_or_scope='{:s}_block_{:d}_repeat_{:d}'.format(
+                            with tf.compat.v1.variable_scope(name_or_scope='{:s}_block_{:d}_repeat_{:d}'.format(
                                     block_op_name, block_index + 1, repeat_index + 1)):
                                 if block_op_name == 'ge':
                                     result = block_op(
@@ -951,7 +954,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         :param name:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             result = self._guided_aggregation_block(
                 detail_input_tensor=detail_output,
                 semantic_input_tensor=semantic_output,
@@ -969,7 +972,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         input_tensor_size = input_tensor.get_shape().as_list()[1:3]
         output_tensor_size = [int(tmp * 8) for tmp in input_tensor_size]
 
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             output_tensor = self._conv_block(
                 input_tensor=input_tensor,
                 k_size=3,
@@ -988,9 +991,10 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
                 use_bias=False,
                 need_activate=False
             )
-            output_tensor = tf.image.resize_bilinear(
+            output_tensor = tf.image.resize(
                 output_tensor,
                 output_tensor_size,
+                method='bilinear',
                 name='instance_logits'
             )
         return output_tensor
@@ -1005,7 +1009,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         input_tensor_size = input_tensor.get_shape().as_list()[1:3]
         output_tensor_size = [int(tmp * 8) for tmp in input_tensor_size]
 
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             output_tensor = self._conv_block(
                 input_tensor=input_tensor,
                 k_size=3,
@@ -1033,9 +1037,10 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
                 use_bias=False,
                 need_activate=False
             )
-            output_tensor = tf.image.resize_bilinear(
+            output_tensor = tf.image.resize(
                 output_tensor,
                 output_tensor_size,
+                method='bilinear',
                 name='binary_logits'
             )
         return output_tensor
@@ -1048,7 +1053,7 @@ class BiseNetV2(cnn_basenet.CNNBaseModel):
         :param reuse:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
             # build detail branch
             detail_branch_output = self.build_detail_branch(
                 input_tensor=input_tensor,
@@ -1091,7 +1096,7 @@ if __name__ == '__main__':
     """
     test code
     """
-    test_in_tensor = tf.placeholder(dtype=tf.float32, shape=[1, 256, 512, 3], name='input')
+    test_in_tensor = tf.compat.v1.placeholder(dtype=tf.float32, shape=[1, 256, 512, 3], name='input')
     model = BiseNetV2(phase='train', cfg=parse_config_utils.lanenet_cfg)
     ret = model.build_model(test_in_tensor, name='bisenetv2')
     for layer_name, layer_info in ret.items():

--- a/semantic_segmentation_zoo/cnn_basenet.py
+++ b/semantic_segmentation_zoo/cnn_basenet.py
@@ -40,7 +40,7 @@ class CNNBaseModel(object):
         :param data_format: default set to NHWC according tensorflow
         :return: tf.Tensor named ``output``
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             in_shape = inputdata.get_shape().as_list()
             channel_axis = 3 if data_format == 'NHWC' else 1
             in_channel = in_shape[channel_axis]
@@ -51,9 +51,19 @@ class CNNBaseModel(object):
             padding = padding.upper()
 
             if isinstance(kernel_size, list):
-                filter_shape = [kernel_size[0], kernel_size[1]] + [in_channel / split, out_channel]
+                filter_shape = [
+                    kernel_size[0],
+                    kernel_size[1],
+                    in_channel // split,
+                    out_channel
+                ]
             else:
-                filter_shape = [kernel_size, kernel_size] + [in_channel / split, out_channel]
+                filter_shape = [
+                    kernel_size,
+                    kernel_size,
+                    in_channel // split,
+                    out_channel
+                ]
 
             if isinstance(stride, list):
                 strides = [1, stride[0], stride[1], 1] if data_format == 'NHWC' \
@@ -63,15 +73,15 @@ class CNNBaseModel(object):
                     else [1, 1, stride, stride]
 
             if w_init is None:
-                w_init = tf.contrib.layers.variance_scaling_initializer()
+                w_init = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
             if b_init is None:
-                b_init = tf.constant_initializer()
+                b_init = tf.compat.v1.constant_initializer()
 
-            w = tf.get_variable('W', filter_shape, initializer=w_init)
+            w = tf.compat.v1.get_variable('W', filter_shape, initializer=w_init)
             b = None
 
             if use_bias:
-                b = tf.get_variable('b', [out_channel], initializer=b_init)
+                b = tf.compat.v1.get_variable('b', [out_channel], initializer=b_init)
 
             if split == 1:
                 conv = tf.nn.conv2d(inputdata, w, strides, padding, data_format=data_format)
@@ -100,15 +110,15 @@ class CNNBaseModel(object):
         :param stride:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             in_shape = input_tensor.get_shape().as_list()
             in_channel = in_shape[3]
             padding = padding.upper()
 
             depthwise_filter_shape = [kernel_size, kernel_size] + [in_channel, depth_multiplier]
-            w_init = tf.contrib.layers.variance_scaling_initializer()
+            w_init = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
 
-            depthwise_filter = tf.get_variable(
+            depthwise_filter = tf.compat.v1.get_variable(
                 name='depthwise_filter_w', shape=depthwise_filter_shape,
                 initializer=w_init
             )
@@ -174,8 +184,14 @@ class CNNBaseModel(object):
             strides = [1, stride, stride, 1] if data_format == 'NHWC' \
                 else [1, 1, stride, stride]
 
-        return tf.nn.max_pool(value=inputdata, ksize=kernel, strides=strides, padding=padding,
-                              data_format=data_format, name=name)
+        return tf.nn.max_pool(
+            input=inputdata,
+            ksize=kernel,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            name=name
+        )
 
     @staticmethod
     def avgpooling(inputdata, kernel_size, stride=None, padding='VALID',
@@ -198,8 +214,14 @@ class CNNBaseModel(object):
 
         strides = [1, stride, stride, 1] if data_format == 'NHWC' else [1, 1, stride, stride]
 
-        return tf.nn.avg_pool(value=inputdata, ksize=kernel, strides=strides, padding=padding,
-                              data_format=data_format, name=name)
+        return tf.nn.avg_pool(
+            input=inputdata,
+            ksize=kernel,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            name=name
+        )
 
     @staticmethod
     def globalavgpooling(inputdata, data_format='NHWC', name=None):
@@ -245,12 +267,12 @@ class CNNBaseModel(object):
             new_shape = [1, channnel]
 
         if use_bias:
-            beta = tf.get_variable('beta', [channnel], initializer=tf.constant_initializer())
+            beta = tf.compat.v1.get_variable('beta', [channnel], initializer=tf.compat.v1.constant_initializer())
             beta = tf.reshape(beta, new_shape)
         else:
             beta = tf.zeros([1] * ndims, name='beta')
         if use_scale:
-            gamma = tf.get_variable('gamma', [channnel], initializer=tf.constant_initializer(1.0))
+            gamma = tf.compat.v1.get_variable('gamma', [channnel], initializer=tf.compat.v1.constant_initializer(1.0))
             gamma = tf.reshape(gamma, new_shape)
         else:
             gamma = tf.ones([1] * ndims, name='gamma')
@@ -288,9 +310,9 @@ class CNNBaseModel(object):
         if not use_affine:
             return tf.divide(inputdata - mean, tf.sqrt(var + epsilon), name='output')
 
-        beta = tf.get_variable('beta', [ch], initializer=tf.constant_initializer())
+        beta = tf.compat.v1.get_variable('beta', [ch], initializer=tf.compat.v1.constant_initializer())
         beta = tf.reshape(beta, new_shape)
-        gamma = tf.get_variable('gamma', [ch], initializer=tf.constant_initializer(1.0))
+        gamma = tf.compat.v1.get_variable('gamma', [ch], initializer=tf.compat.v1.constant_initializer(1.0))
         gamma = tf.reshape(gamma, new_shape)
         return tf.nn.batch_normalization(inputdata, mean, var, beta, gamma, epsilon, name=name)
 
@@ -304,14 +326,19 @@ class CNNBaseModel(object):
         :param noise_shape:
         :return:
         """
-        return tf.nn.dropout(inputdata, keep_prob=keep_prob, noise_shape=noise_shape, name=name)
+        return tf.nn.dropout(
+            input=inputdata,
+            rate=1 - keep_prob,
+            noise_shape=noise_shape,
+            name=name
+        )
 
     @staticmethod
     def fullyconnect(inputdata, out_dim, w_init=None, b_init=None,
                      use_bias=True, name=None):
         """
         Fully-Connected layer, takes a N>1D tensor and returns a 2D tensor.
-        It is an equivalent of `tf.layers.dense` except for naming conventions.
+        It is an equivalent of `tf.compat.v1.layers.dense` except for naming conventions.
 
         :param inputdata:  a tensor to be flattened except for the first dimension.
         :param out_dim: output dimension
@@ -328,14 +355,20 @@ class CNNBaseModel(object):
             inputdata = tf.reshape(inputdata, tf.stack([tf.shape(inputdata)[0], -1]))
 
         if w_init is None:
-            w_init = tf.contrib.layers.variance_scaling_initializer()
+            w_init = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
         if b_init is None:
-            b_init = tf.constant_initializer()
+            b_init = tf.compat.v1.constant_initializer()
 
-        ret = tf.layers.dense(inputs=inputdata, activation=lambda x: tf.identity(x, name='output'),
-                              use_bias=use_bias, name=name,
-                              kernel_initializer=w_init, bias_initializer=b_init,
-                              trainable=True, units=out_dim)
+        dense_layer = tf.keras.layers.Dense(
+            units=out_dim,
+            activation=lambda x: tf.identity(x, name='output'),
+            use_bias=use_bias,
+            kernel_initializer=w_init,
+            bias_initializer=b_init,
+            name=name,
+            trainable=True
+        )
+        ret = dense_layer(inputdata)
         return ret
 
     @staticmethod
@@ -349,7 +382,14 @@ class CNNBaseModel(object):
         :return:
         """
 
-        return tf.layers.batch_normalization(inputs=inputdata, training=is_training, name=name, scale=scale)
+        if isinstance(is_training, tf.Tensor):
+            const_val = tf.get_static_value(is_training)
+            training_flag = bool(const_val) if const_val is not None else False
+        else:
+            training_flag = bool(is_training)
+
+        bn_layer = tf.keras.layers.BatchNormalization(name=name, scale=scale)
+        return bn_layer(inputdata, training=training_flag)
 
     @staticmethod
     def layergn(inputdata, name, group_size=32, esp=1e-5):
@@ -361,7 +401,7 @@ class CNNBaseModel(object):
         :param esp:
         :return:
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             inputdata = tf.transpose(inputdata, [0, 3, 1, 2])
             n, c, h, w = inputdata.get_shape().as_list()
             group_size = min(group_size, c)
@@ -414,7 +454,7 @@ class CNNBaseModel(object):
         :param data_format: default set to NHWC according tensorflow
         :return: tf.Tensor named ``output``
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             in_shape = inputdata.get_shape().as_list()
             channel_axis = 3 if data_format == 'channels_last' else 1
             in_channel = in_shape[channel_axis]
@@ -423,18 +463,24 @@ class CNNBaseModel(object):
             padding = padding.upper()
 
             if w_init is None:
-                w_init = tf.contrib.layers.variance_scaling_initializer()
+                w_init = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
             if b_init is None:
-                b_init = tf.constant_initializer()
+                b_init = tf.compat.v1.constant_initializer()
 
-            ret = tf.layers.conv2d_transpose(inputs=inputdata, filters=out_channel,
-                                             kernel_size=kernel_size,
-                                             strides=stride, padding=padding,
-                                             data_format=data_format,
-                                             activation=activation, use_bias=use_bias,
-                                             kernel_initializer=w_init,
-                                             bias_initializer=b_init, trainable=trainable,
-                                             name=name)
+            conv_t = tf.keras.layers.Conv2DTranspose(
+                filters=out_channel,
+                kernel_size=kernel_size,
+                strides=stride,
+                padding=padding,
+                data_format='channels_last' if data_format == 'NHWC' else 'channels_first',
+                activation=activation,
+                use_bias=use_bias,
+                kernel_initializer=w_init,
+                bias_initializer=b_init,
+                name=name,
+                trainable=trainable
+            )
+            ret = conv_t(inputdata)
         return ret
 
     @staticmethod
@@ -453,7 +499,7 @@ class CNNBaseModel(object):
         :param name:
         :return:
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             in_shape = input_tensor.get_shape().as_list()
             in_channel = in_shape[3]
             assert in_channel is not None, "[Conv2D] Input cannot have unknown channel!"
@@ -466,15 +512,15 @@ class CNNBaseModel(object):
                 filter_shape = [k_size, k_size] + [in_channel, out_dims]
 
             if w_init is None:
-                w_init = tf.contrib.layers.variance_scaling_initializer()
+                w_init = tf.compat.v1.keras.initializers.VarianceScaling(scale=2.0)
             if b_init is None:
-                b_init = tf.constant_initializer()
+                b_init = tf.compat.v1.constant_initializer()
 
-            w = tf.get_variable('W', filter_shape, initializer=w_init)
+            w = tf.compat.v1.get_variable('W', filter_shape, initializer=w_init)
             b = None
 
             if use_bias:
-                b = tf.get_variable('b', [out_dims], initializer=b_init)
+                b = tf.compat.v1.get_variable('b', [out_dims], initializer=b_init)
 
             conv = tf.nn.atrous_conv2d(value=input_tensor, filters=w, rate=rate,
                                        padding=padding, name='dilation_conv')
@@ -501,12 +547,18 @@ class CNNBaseModel(object):
         def f1():
             input_shape = input_tensor.get_shape().as_list()
             noise_shape = tf.constant(value=[input_shape[0], 1, 1, input_shape[3]])
-            return tf.nn.dropout(input_tensor, keep_prob, noise_shape, seed=seed, name="spatial_dropout")
+            return tf.nn.dropout(
+                input_tensor,
+                rate=1 - keep_prob,
+                noise_shape=noise_shape,
+                seed=seed,
+                name="spatial_dropout"
+            )
 
         def f2():
             return input_tensor
 
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
 
             output = tf.cond(is_training, f1, f2)
 
@@ -521,5 +573,5 @@ class CNNBaseModel(object):
         :param name:
         :return:
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             return tf.nn.relu(inputdata) - alpha * tf.nn.relu(-inputdata)

--- a/semantic_segmentation_zoo/vgg16_based_fcn.py
+++ b/semantic_segmentation_zoo/vgg16_based_fcn.py
@@ -56,7 +56,7 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
         :param need_layer_norm:
         :return:
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
             conv = self.conv2d(
                 inputdata=input_tensor, out_channel=out_dims,
                 kernel_size=k_size, stride=stride,
@@ -88,7 +88,7 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
         :param name:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
 
             deconv_weights_stddev = tf.sqrt(
                 tf.divide(tf.constant(2.0, tf.float32),
@@ -129,7 +129,7 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
         :param name:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name):
+        with tf.compat.v1.variable_scope(name_or_scope=name):
             # encode stage 1
             conv_1_1 = self._vgg16_conv_stage(
                 input_tensor=input_tensor, k_size=3,
@@ -269,10 +269,10 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
 
         :return:
         """
-        with tf.variable_scope(name):
+        with tf.compat.v1.variable_scope(name):
 
             # decode part for binary segmentation
-            with tf.variable_scope(name_or_scope='binary_seg_decode'):
+            with tf.compat.v1.variable_scope(name_or_scope='binary_seg_decode'):
 
                 decode_stage_5_binary = self._net_intermediate_results['encode_stage_5_binary']['data']
 
@@ -317,7 +317,7 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
                     'shape': binary_final_logits.get_shape().as_list()
                 }
 
-            with tf.variable_scope(name_or_scope='instance_seg_decode'):
+            with tf.compat.v1.variable_scope(name_or_scope='instance_seg_decode'):
 
                 decode_stage_5_instance = self._net_intermediate_results['encode_stage_5_instance']['data']
 
@@ -354,7 +354,7 @@ class VGG16FCN(cnn_basenet.CNNBaseModel):
         :param reuse:
         :return:
         """
-        with tf.variable_scope(name_or_scope=name, reuse=reuse):
+        with tf.compat.v1.variable_scope(name_or_scope=name, reuse=reuse):
             # vgg16 fcn encode part
             self._vgg16_fcn_encode(input_tensor=input_tensor, name='vgg16_encode_module')
             # vgg16 fcn decode part


### PR DESCRIPTION
## Summary
- handle boolean training flag for BatchNormalization
- adapt pooling and dropout calls for TF2
- replace deprecated `tf.image.resize_bilinear`
- return boolean from `_is_net_for_training`

## Testing
- `python -m tools.test_lanenet --weights_path tusimple_lanenet.ckpt --image_path ./data/tusimple_test_image/0.jpg` *(passed, detected lanes)*

------
https://chatgpt.com/codex/tasks/task_e_686dd007049c8326944a727f8818fa08